### PR TITLE
Convert to int64 if specified as 'integer'.

### DIFF
--- a/hydra/fileformat.go
+++ b/hydra/fileformat.go
@@ -46,7 +46,7 @@ func (c BoolConverter) Convert(v string) (interface{}, error) {
 }
 
 func (c IntConverter) Convert(v string) (interface{}, error) {
-	return strconv.Atoi(v)
+	return strconv.ParseInt(v, 10, 64)
 }
 
 func (c FloatConverter) Convert(v string) (interface{}, error) {
@@ -137,6 +137,18 @@ func (c ConvertMap) ConvertTypes(data map[string]interface{}) {
 			default:
 				continue
 			case float64:
+				if c.TypeMap[key] == ConvertTypeInt {
+					data[key] = int64(value)
+				}
+			case float32:
+				if c.TypeMap[key] == ConvertTypeInt {
+					data[key] = int64(value)
+				}
+			case int:
+				if c.TypeMap[key] == ConvertTypeInt {
+					data[key] = int64(value)
+				}
+			case int32:
 				if c.TypeMap[key] == ConvertTypeInt {
 					data[key] = int64(value)
 				}

--- a/hydra/fileformat_test.go
+++ b/hydra/fileformat_test.go
@@ -8,15 +8,17 @@ import (
 )
 
 func TestConvertMap(t *testing.T) {
-	convertMap := hydra.NewConvertMap("user_id:integer,paid:bool,paid_user_amount:float")
+	convertMap := hydra.NewConvertMap("user_id:integer,paid:bool,paid_user_amount:float,bar:integer,baz:integer")
 	data := map[string]interface{}{
 		"user_id":          "12345",
 		"paid":             "true",
 		"paid_user_amount": "1.234",
 		"foo":              "45678",
+		"bar":              float64(67890),
+		"baz":              98765,
 	}
 	convertMap.ConvertTypes(data)
-	if data["user_id"] != 12345 {
+	if data["user_id"] != int64(12345) {
 		t.Errorf("convert integer failed")
 	}
 	if data["paid"] != true {
@@ -27,6 +29,12 @@ func TestConvertMap(t *testing.T) {
 	}
 	if data["foo"] != "45678" {
 		t.Errorf("foo must be not converted %#v", data["foo"])
+	}
+	if data["bar"] != int64(67890) {
+		t.Errorf("bar must be not converted %#v", data["bar"])
+	}
+	if data["baz"] != int64(98765) {
+		t.Errorf("baz must be not converted %#v", data["baz"])
 	}
 }
 

--- a/hydra/in_tail_json_test.go
+++ b/hydra/in_tail_json_test.go
@@ -12,12 +12,14 @@ import (
 
 var (
 	JSONLogs = []string{
+		`{"foo":"1","bar":"2","time":"2014-12-31T12:00:01+09:00"}` + "\n",
 		`{"foo":"1","bar":2,"time":"2014-12-31T12:00:01+09:00"}` + "\n",
 		`{"foo":"123","time":"2015-04-29T00:00:00Z"}` + "\n",
 		`{"bar":"baz"}` + "\n",
 		"invalid JSON line\n",
 	}
 	JSONParsed = []map[string]interface{}{
+		{"foo": "1", "bar": int64(2), "_time": time.Date(2014, time.December, 31, 12, 00, 01, 0, JST)},
 		{"foo": "1", "bar": int64(2), "_time": time.Date(2014, time.December, 31, 12, 00, 01, 0, JST)},
 		{"foo": "123", "_time": time.Date(2015, time.April, 29, 00, 00, 00, 0, time.UTC)},
 		{"bar": "baz"},
@@ -65,14 +67,14 @@ func TestTrailJSON(t *testing.T) {
 		for _, _record := range recordSet.Records {
 			record := _record.(*fluent.TinyFluentRecord)
 			if foo, _ := record.GetData("foo"); foo != JSONParsed[i]["foo"] {
-				t.Errorf("unexpected record got:foo=%#v expected:%#v", foo, JSONParsed[i]["foo"])
+				t.Errorf("unexpected record[%d] got:foo=%#v expected:%#v", i, foo, JSONParsed[i]["foo"])
 			}
 			if bar, _ := record.GetData("bar"); bar != JSONParsed[i]["bar"] {
-				t.Errorf("unexpected record got:bar=%#v expected:%#v", bar, JSONParsed[i]["bar"])
+				t.Errorf("unexpected record[%d] got:bar=%#v expected:%#v %#v", i, bar, JSONParsed[i]["bar"], record)
 			}
 			if ts, ok := JSONParsed[i]["_time"]; ok {
 				if ts.(time.Time).Unix() != record.Timestamp {
-					t.Errorf("expected timestamp %s got %s", ts, record.Timestamp)
+					t.Errorf("expected record[%d] timestamp %s got %s", i, ts, record.Timestamp)
 				}
 			}
 			i++

--- a/hydra/in_tail_ltsv_test.go
+++ b/hydra/in_tail_ltsv_test.go
@@ -21,9 +21,9 @@ var (
 		"invalid LTSV line\n",
 	}
 	LTSVParsed = []map[string]interface{}{
-		{"foo": 1, "bar": "2", "_time": time.Date(2015, time.May, 26, 11, 22, 33, 0, time.UTC)},
+		{"foo": int64(1), "bar": "2", "_time": time.Date(2015, time.May, 26, 11, 22, 33, 0, time.UTC)},
 		{"foo": "AAA", "bar": "BBB", "_time": time.Date(2013, time.November, 22, 04, 21, 31, 0, JST)},
-		{"foo": 123},
+		{"foo": int64(123)},
 		{"bar": "baz"},
 		{"message": "invalid LTSV line"},
 	}


### PR DESCRIPTION
When a format specified 'integer', always convert to int64.
