### PR TITLE
optimization: reduced memory allocations for append().

### DIFF
--- a/hydra/hydra.go
+++ b/hydra/hydra.go
@@ -84,7 +84,7 @@ func NewFluentRecordSetLTSV(tag string, key string, mod *RecordModifier, buffer 
 func NewFluentRecordSetJSON(tag string, key string, mod *RecordModifier, buffer []byte) *fluent.FluentRecordSet {
 	timestamp := time.Now().Unix()
 	lines := bytes.Split(buffer, LineSeparator)
-	records := make([]fluent.FluentRecordType, 0)
+	records := make([]fluent.FluentRecordType, 0, len(lines))
 	for _, line := range lines {
 		data := make(map[string]interface{})
 		err := json.Unmarshal(line, &data)

--- a/hydra/hydra_recordset_test.go
+++ b/hydra/hydra_recordset_test.go
@@ -1,0 +1,52 @@
+package hydra_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fujiwara/fluent-agent-hydra/hydra"
+)
+
+func createRecordsetSample(n int) string {
+	data := `{"foo":"1","bar":"2","hoge":"3","fuga":"4","hoga":"5","hobar":"6","time":"2015-10-29T10:17:45+09:00"}
+`
+	return strings.TrimRight(strings.Repeat(data, n), "\n")
+}
+
+func TestNewFluentRecordSetLTSV(t *testing.T) {
+	buf := []byte(createRecordsetSample(1))
+	record := hydra.NewFluentRecordSetLTSV("dummy", "message", nil, buf)
+	if record.Tag != "dummy" {
+		t.Errorf("invalid tag: %s", record.Tag)
+	}
+	if len(record.Records) != 1 {
+		t.Errorf("invalid record length: %#v", len(record.Records))
+	}
+}
+
+func TestNewFluentRecordSetJSON(t *testing.T) {
+	buf := []byte(createRecordsetSample(1))
+	record := hydra.NewFluentRecordSetJSON("dummy", "message", nil, buf)
+	if record.Tag != "dummy" {
+		t.Errorf("invalid tag: %s", record.Tag)
+	}
+	if len(record.Records) != 1 {
+		t.Errorf("invalid record length: %#v", len(record.Records))
+	}
+}
+
+func BenchmarkNewFluentRecordSetLTSV(b *testing.B) {
+	b.ResetTimer()
+	buf := []byte(createRecordsetSample(10))
+	for i := 0; i < b.N; i++ {
+		_ = hydra.NewFluentRecordSetLTSV("dummy", "message", nil, buf)
+	}
+}
+
+func BenchmarkNewFluentRecordSetJSON(b *testing.B) {
+	b.ResetTimer()
+	buf := []byte(createRecordsetSample(10))
+	for i := 0; i < b.N; i++ {
+		_ = hydra.NewFluentRecordSetJSON("dummy", "message", nil, buf)
+	}
+}


### PR DESCRIPTION
As the size of `lines` is known before running append(), make() reserves the capacity for `records` as same as it.

## Benchmark

There are simple tests and bechmarks for recordset-creation in https://github.com/fujiwara/fluent-agent-hydra/commit/74f186ea4dcf2e5aff867b4eda17771c6c33bc02.

### Before

```console
$ go test -run=nonthingplease -bench NewFluentRecordSetJSON -count 5 -benchmem -benchtime=3s
PASS
BenchmarkNewFluentRecordSetJSON-8          50000            101019 ns/op           19424 B/op        627 allocs/op
BenchmarkNewFluentRecordSetJSON-8          50000            101360 ns/op           19424 B/op        627 allocs/op
BenchmarkNewFluentRecordSetJSON-8          50000            100986 ns/op           19424 B/op        627 allocs/op
BenchmarkNewFluentRecordSetJSON-8          50000            101244 ns/op           19424 B/op        627 allocs/op
BenchmarkNewFluentRecordSetJSON-8          50000            100513 ns/op           19424 B/op        627 allocs/op
ok      github.com/fujiwara/fluent-agent-hydra/hydra    30.368s
```

### After

```console
$ go test -run=nonthingplease -bench NewFluentRecordSetJSON -count 5 -benchmem -benchtime=3s
PASS
BenchmarkNewFluentRecordSetJSON-8          50000             99576 ns/op           19088 B/op        623 allocs/op
BenchmarkNewFluentRecordSetJSON-8          50000            100329 ns/op           19088 B/op        623 allocs/op
BenchmarkNewFluentRecordSetJSON-8          50000             99746 ns/op           19088 B/op        623 allocs/op
BenchmarkNewFluentRecordSetJSON-8          50000             99744 ns/op           19088 B/op        623 allocs/op
BenchmarkNewFluentRecordSetJSON-8          50000             99933 ns/op           19088 B/op        623 allocs/op
ok      github.com/fujiwara/fluent-agent-hydra/hydra    30.064s
```