### PR TITLE
output compiler version for showVersion.

### DIFF
--- a/cmd/fluent-agent-hydra/main.go
+++ b/cmd/fluent-agent-hydra/main.go
@@ -43,6 +43,7 @@ func main() {
 
 	if showVersion {
 		fmt.Println("version:", version)
+		fmt.Printf("compiler:%s %s\n", runtime.Compiler, runtime.Version())
 		fmt.Println("build:", buildDate)
 		os.Exit(0)
 	}


### PR DESCRIPTION
If compiler version is visible after built, it is useful.