### PR TITLE
build: new syntax for -X flag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,5 @@ get-deps:
 	go get -t -d -v ./fluent/ ./hydra/
 
 binary:
-	cd cmd/fluent-agent-hydra && gox -os="linux darwin windows" -arch="amd64 386" -output "../../pkg/{{.Dir}}-${GIT_VER}-{{.OS}}-{{.Arch}}" -ldflags "-X main.version ${GIT_VER} -X main.buildDate ${DATE}"
+	cd cmd/fluent-agent-hydra && gox -os="linux darwin windows" -arch="amd64 386" -output "../../pkg/{{.Dir}}-${GIT_VER}-{{.OS}}-{{.Arch}}" -ldflags "-X main.version=${GIT_VER} -X main.buildDate=${DATE}"
 	cd pkg && find . -name "*${GIT_VER}*" -type f -exec zip {}.zip {} \;


### PR DESCRIPTION
`-X importpath.name value` is old syntax. According to the release note of 1.6, it will be removed in Go1.7.

https://golang.org/doc/go1.6#compiler