### PR TITLE
use djson

### DIFF
--- a/hydra/hydra.go
+++ b/hydra/hydra.go
@@ -2,13 +2,13 @@ package hydra
 
 import (
 	"bytes"
-	"encoding/json"
 	"log"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/a8m/djson"
 	"github.com/fujiwara/fluent-agent-hydra/fluent"
 )
 
@@ -129,9 +129,9 @@ func NewFluentRecordLTSV(key string, line []byte) *fluent.TinyFluentRecord {
 }
 
 func NewFluentRecordJSON(key string, line []byte) *fluent.TinyFluentRecord {
-	data := make(map[string]interface{})
-	err := json.Unmarshal(line, &data)
+	data, err := djson.DecodeObject(line)
 	if err != nil {
+		data = make(map[string]interface{}, 1)
 		data[key] = string(line)
 	}
 	return &fluent.TinyFluentRecord{Data: data}


### PR DESCRIPTION
github.com/a8m/djson

> DJSON is a JSON decoder for Go that is 2~ to 3~ times faster than the standard encoding/json and the existing solutions, when dealing with arbitrary JSON payload.