### PR TITLE
Fix test fail message

### DIFF
--- a/hydra/config_test.go
+++ b/hydra/config_test.go
@@ -17,7 +17,7 @@ func TestReadConfig(t *testing.T) {
 		t.Error("invalid TagPrefix got", config.TagPrefix, "expected", "foo")
 	}
 	if config.FieldName != "message" {
-		t.Error("invalid FieldName got", config.FieldName, "expected", "msg")
+		t.Error("invalid FieldName got", config.FieldName, "expected", "message")
 	}
 	if config.ReadBufferSize != 1024 {
 		t.Error("invalid ReadBufferSize got", config.ReadBufferSize)


### PR DESCRIPTION
Text change only; no impact on test itself.

The text output when "message" is not matched incorrectly says that the expected text was "msg".  Given that "msg" really is tested later on for bar.log, this could be confusing.
