### PR TITLE
Add hostname to a configurable field name

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,34 @@ Types = "column_name:integer"
 
 Its type is converted to int64.
 
+### Hostname field support
+
+To add the current hostname to a record read from a log, the config file option `HostnameKey` may be specified in the global settings or `[[Logs]]` section. This configures the field name that will hold the hostname, as determined by [os.Hostname()](http://golang.org/pkg/os/#Hostname).
+
+Currently, the hostname is only added when tailing logs with formats other than "None". If a key of the same name is already parsed from the log (for example, if reading from syslog which has the hostname in the message), the value parsed is preserved.  Logs read in by receivers are not affected.
+
+Example HostnameKey.
+
+```toml
+# global settings
+HostnameKey = "host"      # default ""
+
+[[Logs]]
+# uses global HostnameKey
+File = "/var/log/nginx/access.log"
+Tag = "access"
+Format = "LTSV"
+
+[[Logs]]
+# "host" will be captured via syslog regexp
+# store os.Hostname() into a different key
+File = "/var/log/messages"
+HostnameKey = "fqdn"
+Format = "Regexp"
+Regexp = "syslog"
+TimeFormat = "syslog"
+```
+
 ## Stats monitor
 
 For enabling stats monitor, specify command line option `-m host:port` or `[Monitor]` section in config file.

--- a/hydra/config.go
+++ b/hydra/config.go
@@ -20,6 +20,7 @@ const (
 var DefaultTimeFormat = TimeFormat(time.RFC3339)
 
 type Config struct {
+	HostnameKey      string
 	TagPrefix        string
 	FieldName        string
 	ReadBufferSize   int
@@ -37,15 +38,16 @@ type ConfigServer struct {
 }
 
 type ConfigLogfile struct {
-	Tag        string
-	File       string
-	FieldName  string
-	Format     FileFormat
-	Regexp     *Regexp
-	ConvertMap ConvertMap `toml:"Types"`
-	TimeParse  bool
-	TimeKey    string
-	TimeFormat TimeFormat
+	HostnameKey string
+	Tag         string
+	File        string
+	FieldName   string
+	Format      FileFormat
+	Regexp      *Regexp
+	ConvertMap  ConvertMap `toml:"Types"`
+	TimeParse   bool
+	TimeKey     string
+	TimeFormat  TimeFormat
 }
 
 type ConfigReceiver struct {
@@ -149,6 +151,9 @@ func (cl *ConfigLogfile) IsStdin() bool {
 func (cl *ConfigLogfile) Restrict(c *Config) {
 	if cl.FieldName == "" {
 		cl.FieldName = c.FieldName
+	}
+	if cl.HostnameKey == "" {
+		cl.HostnameKey = c.HostnameKey
 	}
 	if c.TagPrefix != "" {
 		cl.Tag = c.TagPrefix + "." + cl.Tag

--- a/hydra/config_test.go
+++ b/hydra/config_test.go
@@ -13,6 +13,9 @@ func TestReadConfig(t *testing.T) {
 		t.Error("read config failed", err)
 	}
 	fmt.Printf("%#v\n", config)
+	if config.HostnameKey != "host" {
+		t.Error("invalid HostnameKey got", config.HostnameKey, "expected", "host")
+	}
 	if config.TagPrefix != "foo" {
 		t.Error("invalid TagPrefix got", config.TagPrefix, "expected", "foo")
 	}
@@ -42,6 +45,7 @@ func TestReadConfig(t *testing.T) {
 	if c := config.Logs[0]; c.Tag != "foo.tag1" ||
 		c.File != "/tmp/foo.log" ||
 		c.FieldName != "message" ||
+		c.HostnameKey != "fqdn" ||
 		c.TimeParse != false {
 		t.Errorf("invalid Logs[0] got %#v", c)
 	}
@@ -49,6 +53,7 @@ func TestReadConfig(t *testing.T) {
 	if c := config.Logs[1]; c.Tag != "foo.tag2" ||
 		c.File != "/tmp/bar.log" ||
 		c.FieldName != "msg" ||
+		c.HostnameKey != "host" ||
 		c.TimeParse != false {
 		t.Errorf("invalid Logs[1] got %#v", c)
 	}

--- a/hydra/config_test.toml
+++ b/hydra/config_test.toml
@@ -1,3 +1,4 @@
+HostnameKey = "host"
 TagPrefix = "foo"    # comment
 ReadBufferSize = 1024
 ServerRoundRobin = true
@@ -14,6 +15,7 @@ Host = "127.0.0.1"
 Port = 24225
 
 [[Logs]]
+HostnameKey = "fqdn"
 Tag  = "tag1"
 File = "/tmp/foo.log"
 

--- a/hydra/fileformat.go
+++ b/hydra/fileformat.go
@@ -2,6 +2,7 @@ package hydra
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -62,6 +63,10 @@ var (
 	convertFloat FloatConverter
 )
 
+var (
+	hostname, hostnameErr = os.Hostname()
+)
+
 func (c BoolConverter) Convert(v string) (interface{}, error) {
 	return strconv.ParseBool(v)
 }
@@ -85,12 +90,18 @@ type ConvertMap struct {
 
 type RecordModifier struct {
 	convertMap    ConvertMap
+	hostnameKey   string
 	timeParse     bool
 	timeKey       string
 	timeConverter TimeConverter
 }
 
 func (m *RecordModifier) Modify(r *fluent.TinyFluentRecord) {
+	if m.hostnameKey != "" && hostnameErr == nil {
+		if _, ok := r.Data[m.hostnameKey]; ok == false {
+			r.Data[m.hostnameKey] = hostname
+		}
+	}
 	if m.convertMap.ConverterMap != nil {
 		m.convertMap.ConvertTypes(r.Data)
 	}

--- a/hydra/in_tail.go
+++ b/hydra/in_tail.go
@@ -110,6 +110,7 @@ func Rel2Abs(filename string) (string, error) {
 func NewInTail(config *ConfigLogfile, watcher *Watcher) (*InTail, error) {
 	modifier := &RecordModifier{
 		convertMap:    config.ConvertMap,
+		hostnameKey:   config.HostnameKey,
 		timeParse:     config.TimeParse,
 		timeKey:       config.TimeKey,
 		timeConverter: TimeConverter(config.TimeFormat),


### PR DESCRIPTION
Inspired by fluentd in_forward's source_hostname_key, but done on the endpoint
so that in_forward doesn't have to split apart and re-contruct messagepack
record sets, and so the hostname is used instead of an IP address.

This is useful when using Fluentd to send to a centralized logging system like
Graylog that requires a hostname entry for logs.

Note, format="None" logs use a custom Fluent message structure and do not use a
RecordModifier so hostnames are not added there.  (I was unsure why there were were multiple implementations of message sending.)

Note, RecordModifier seemed like the best place to put this, given the name of the structure, however, the name of the file, "fileformat.go", implies that it is about parsing file contents, which adding the hostname is not.  I could see instead adding this functionality into hydra.go's NewFluentRecordSet, perhaps using helper function that is called after Modify().  I'd be happy to refactor if that is the better place for this.