### PR TITLE
Add support of []interface{} to func coerceInPlace

### DIFF
--- a/fluent/server.go
+++ b/fluent/server.go
@@ -195,11 +195,32 @@ func (e *EventTimeExtension) ReadExt(dst interface{}, src []byte) {
 	}
 }
 
+func coerceInPlaceInArray(data []interface{}) []interface{} {
+	var newArr []interface{} = make([]interface{}, len(data))
+	for i, av := range data {
+		switch v2_ := av.(type) {
+		case []byte:
+			newArr[i] = string(v2_)
+		case []interface{}:
+			na := coerceInPlaceInArray(v2_)
+			newArr[i] = na
+		case map[string]interface{}:
+			coerceInPlace(v2_)
+		default:
+			newArr[i] = av
+		}
+	}
+	return newArr
+}
+
 func coerceInPlace(data map[string]interface{}) {
 	for k, v := range data {
 		switch v_ := v.(type) {
 		case []byte:
 			data[k] = string(v_) // XXX: byte => rune
+		case []interface{}:
+			na := coerceInPlaceInArray(v_)
+			data[k] = na
 		case map[string]interface{}:
 			coerceInPlace(v_)
 		}


### PR DESCRIPTION
The current implementation did not support the case when the field was an array of interfaces and when decoding instead of text was a bass64