### PR TITLE
set SetWriteDeadline in Fluent.Send

### DIFF
--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -214,6 +214,7 @@ func (f *Fluent) Send(buffer []byte) (err error) {
 		f.recordError(err)
 		return
 	} else {
+		f.conn.SetWriteDeadline(time.Now().Add(f.Config.Timeout))
 		_, err = f.conn.Write(buffer)
 		if err != nil {
 			f.recordError(err)


### PR DESCRIPTION
Currently, no timeout for `(*net.Conn).Write()` is set.
This may cause a permanent stuck when the target server cannot respond.

A timeout makes a reconnection with DNS round robin in `(*Fluent).connect()`