### PR TITLE
set current time to record parsed from JSON, LTSV, Regexp

### DIFF
--- a/hydra/hydra.go
+++ b/hydra/hydra.go
@@ -85,18 +85,21 @@ func NewFluentRecordSet(tag, key string, format FileFormat, mod *RecordModifier,
 			records = append(records, r)
 		case FormatLTSV:
 			r := NewFluentRecordLTSV(key, msg)
+			r.Timestamp = t
 			if mod != nil {
 				mod.Modify(r)
 			}
 			records = append(records, r)
 		case FormatJSON:
 			r := NewFluentRecordJSON(key, msg)
+			r.Timestamp = t
 			if mod != nil {
 				mod.Modify(r)
 			}
 			records = append(records, r)
 		case FormatRegexp:
 			r := NewFluentRecordRegexp(key, msg, reg)
+			r.Timestamp = t
 			if mod != nil {
 				mod.Modify(r)
 			}


### PR DESCRIPTION
This fixes the breaking change included in #17 in LTSV and JSON data parsing.

----

Before #17 , the *current time* was added to records as the default timestamp. ([code](https://github.com/fujiwara/fluent-agent-hydra/pull/17/files#diff-5859b1247cc4039f86b86c3a07cfc47fL70))

But now, no default timestamp is set except for `FormatNone`, so zero time is recorded when `TimeParse = false`. ([code](https://github.com/fujiwara/fluent-agent-hydra/pull/17/files#diff-5859b1247cc4039f86b86c3a07cfc47fR88))

This PR sets the default timestamp for records which are parsed from LTSV, JSON and Regexp.
If `TimeParse = true` and a record contains the valid timestamp, `mod.Modify(r)` in the next line will change its timestamp.