### PR TITLE
install into default location if GOPATH is unset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GIT_VER := $(shell git describe --tags)
 DATE := $(shell date +%Y-%m-%dT%H:%M:%S%z)
+GOPATH ?= ${HOME}/go
 
 .PHONY: test binary all fmt clean
 


### PR DESCRIPTION
The install step fails if the GOPATH is unset. Since go has a default
for GOPATH in `$HOME/go` lets use that in case it is not defined.