### PR TITLE
fix copyandpaste lint error

### DIFF
--- a/hydra/fileformat.go
+++ b/hydra/fileformat.go
@@ -232,7 +232,7 @@ func (t *TimeFormat) UnmarshalText(text []byte) error {
 	case "apache":
 		*t = TimeFormatApache
 	case "nginx":
-		*t = TimeFormatApache
+		*t = TimeFormatNginx
 	case "syslog":
 		*t = TimeFormatSyslog
 	default:


### PR DESCRIPTION
I was write a linter  https://github.com/alingse/copyandpaste that detect the same code in different branch.

this is mostly a copy and paste things. 

I search and post the popular repo in the github and run the workflow.

Here is this repo's result log.

```
Error: /home/runner/work/copyandpaste/copyandpaste/fluent-agent-hydra/hydra/fileformat.go:234:2: Duplicate case body found for case "nginx": and case "apache": Is it a copy and paste?
```

from the code context. I think this is a bug.
